### PR TITLE
feat: user selection of the sampling dset

### DIFF
--- a/dataprovider3/dataprovider.py
+++ b/dataprovider3/dataprovider.py
@@ -43,15 +43,17 @@ class DataProvider(object):
         assert len(p)==len(self.datasets)
         self.p = p
 
-    def random_dataset(self):
+    def random_dataset_idx(self):
         assert len(self.datasets) > 0
         if self.p is None:
             self.set_sampling_weights()
-        idx = np.random.choice(len(self.datasets), size=1, p=self.p)
-        return self.datasets[idx[0]]
+        return np.random.choice(len(self.datasets), size=1, p=self.p)[0]
 
-    def random_sample(self):
-        dset = self.random_dataset()
+    def random_dataset(self):
+        return self.datasets[self.random_dataset_idx()]
+
+    def random_sample(self, idx=None):
+        dset = self.random_dataset() if idx is None else self.datasets[idx]
         out_of_range_count = 0  # Out-of-range error count
         while True:
             try:

--- a/dataprovider3/datasuperset.py
+++ b/dataprovider3/datasuperset.py
@@ -31,8 +31,8 @@ class DataSuperset(Dataset):
         assert isinstance(dset, Dataset)
         self.datasets.append(dset)
 
-    def random_sample(self, spec=None):
-        dset = self.random_dataset()
+    def random_sample(self, spec=None, idx=None):
+        dset = self.random_dataset() if idx is None else self.datasets[idx]
         return dset(spec=spec)
 
     def set_sampling_weights(self, p=None):
@@ -43,12 +43,14 @@ class DataSuperset(Dataset):
         assert len(p)==len(self.datasets)
         self.p = p
 
-    def random_dataset(self):
+    def random_dataset_idx(self):
         assert len(self.datasets) > 0
         if self.p is None:
             self.set_sampling_weights()
-        idx = np.random.choice(len(self.datasets), size=1, p=self.p)
-        return self.datasets[idx[0]]
+        return np.random.choice(len(self.datasets), size=1, p=self.p)[0]
+
+    def random_dataset(self):
+        return self.datasets[self.random_dataset_idx()]
 
     def num_samples(self, spec=None):
         return sum([dset.num_samples(spec=spec) for dset in self.datasets])


### PR DESCRIPTION
It can be useful to control which dataset the DataProvider samples from when using `DataProvider.random_sample`. For example, in synapse assignment the current sampling procedure processes patches from the DataProvider by highlighting a particular segment ID from the pre & postsynaptic side. Knowing which IDs to highlight requires knowing which dataset was used for sampling.

This PR makes some minor changes to `random_sample` and `random_dataset` and provides a new class method for DataProvider and DataSuperset. The same changes are made to both classes.
* `random_dataset_idx` takes the index sampling logic from `random_dataset` and makes it into a separate method.
* `random_dataset` just selects from `self.datasets` after calling `random_dataset_idx` now that the sampling logic has been removed
* `random_sample` takes an `idx` argument, which defaults to `None`. The method samples from the dataset at `idx` if that argument is not `None`, and otherwise calls `random_dataset` as usual.